### PR TITLE
Application Crash Detection Query

### DIFF
--- a/General queries/Crashing Applications.csl
+++ b/General queries/Crashing Applications.csl
@@ -4,6 +4,7 @@
 // to werfault.exe 
 ///////////////////////////////////////////////////////////////////
 DeviceProcessEvents
+| where Timestamp > ago(1d)
 | where FileName =~ 'werfault.exe'
 | project CrashTime = Timestamp, DeviceId, WerFaultCommand = ProcessCommandLine, CrashProcessId = extract("-p ([0-9]{1,5})", 1, ProcessCommandLine) 
 | join kind= inner hint.strategy=shuffle DeviceProcessEvents on DeviceId

--- a/General queries/Crashing Applications.csl
+++ b/General queries/Crashing Applications.csl
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////
+// Crash Detector
+// This query identifies crashing processes based on parameters passed
+// to werfault.exe 
+///////////////////////////////////////////////////////////////////
+DeviceProcessEvents
+| where FileName =~ 'werfault.exe'
+| project CrashTime = Timestamp, DeviceId, WerFaultCommand = ProcessCommandLine, CrashProcessId = extract("-p ([0-9]{1,5})", 1, ProcessCommandLine) 
+| join kind= inner hint.strategy=shuffle DeviceProcessEvents on DeviceId
+| where CrashProcessId == ProcessId and Timestamp between (datetime_add('day',-1,CrashTime) .. CrashTime)
+| project-away ActionType
+| project-rename ProcessStartTimestamp = Timestamp


### PR DESCRIPTION
This query will identify applications which are crashing based on parameters passed to werfault.exe.  Process must've started within 1 day of its crash timestamp, though this is adjustable on line 10