### PR TITLE
Create Device network events w low count FQDN.csl

### DIFF
--- a/Command and Control/Device network events w low count FQDN.csl
+++ b/Command and Control/Device network events w low count FQDN.csl
@@ -7,12 +7,14 @@
 // network communication.
 ////////////////////////////////////////////////////////////////////////////////////
 DeviceNetworkEvents
+| where Timestamp > ago(1h)
 | where InitiatingProcessFileName !in~ ('iexplore.exe','chrome.exe','opera.exe','safari.exe') // Remove web browsers
     and isnotempty(RemoteUrl)
 | extend FQDN = iff(RemoteUrl matches regex "^([a-zA-Z0-9._-])+$", tostring(RemoteUrl), parse_url(RemoteUrl).domain)
-| top-nested 10000 of FQDN by dcount(DeviceId) asc
+| top-nested 100 of FQDN by dcount(DeviceId) asc
 | join kind=inner (
     DeviceNetworkEvents
+    | where Timestamp > ago(1h)
     | where isnotempty(RemoteUrl)
     | extend FQDN = iff(RemoteUrl matches regex "^([a-zA-Z0-9._-])+$", tostring(RemoteUrl), parse_url(RemoteUrl).domain)
 ) on FQDN

--- a/Command and Control/Device network events w low count FQDN.csl
+++ b/Command and Control/Device network events w low count FQDN.csl
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////////
+// Device Network Events Involving Low Count FQDNs
+//
+// This query reduces network events to only those with the RemoteURL column populated,
+// then parses the DNS name from the URL (if needed) and finds the least prevalent 
+// FQDNs.  The result is then joined with DeviceNetworkEvents to highlight anomalous
+// network communication.
+////////////////////////////////////////////////////////////////////////////////////
+DeviceNetworkEvents
+| where InitiatingProcessFileName !in~ ('iexplore.exe','chrome.exe','opera.exe','safari.exe') // Remove web browsers
+    and isnotempty(RemoteUrl)
+| extend FQDN = iff(RemoteUrl matches regex "^([a-zA-Z0-9._-])+$", tostring(RemoteUrl), parse_url(RemoteUrl).domain)
+| top-nested 10000 of FQDN by dcount(DeviceId) asc
+| join kind=inner (
+    DeviceNetworkEvents
+    | where isnotempty(RemoteUrl)
+    | extend FQDN = iff(RemoteUrl matches regex "^([a-zA-Z0-9._-])+$", tostring(RemoteUrl), parse_url(RemoteUrl).domain)
+) on FQDN
+| order by aggregated_FQDN asc


### PR DESCRIPTION
This query reduces network events to only those with the RemoteURL column populated, then parses the DNS name from the URL (if needed) and finds the least prevalent FQDNs.  The result is then joined with DeviceNetworkEvents to highlight anomalous network communication.