### PR TITLE
Added new ASR rules

### DIFF
--- a/Protection events/ExploitGuardASRStats.txt
+++ b/Protection events/ExploitGuardASRStats.txt
@@ -2,13 +2,13 @@
 DeviceEvents
 | where ActionType startswith "Asr" and ActionType endswith "Audited"
 // Count total stats - count events and machines per rule
-| summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
+| summarize EventCount=count(), MachinesCount=dcount(DeviceId) by ActionType
 
 // Get stats on ASR blocks - count events and machines per rule
 DeviceEvents
 | where ActionType startswith "Asr" and ActionType endswith "Blocked"
 // Count total stats - count events and machines per rule
-| summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
+| summarize EventCount=count(), MachinesCount=dcount(DeviceId) by ActionType
 
 // View ASR audit events - but remove repeating events (e.g. multiple events with same machine, rule, file and process)
 DeviceEvents

--- a/Protection events/ExploitGuardASRStats.txt
+++ b/Protection events/ExploitGuardASRStats.txt
@@ -4,17 +4,14 @@ DeviceEvents
 | where ActionType startswith "Asr" and ActionType endswith "Audited"
 // Count total stats - count events and machines per rule
 | summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
-| render piechart
 
 // Get stats on ASR blocks - count events and machines per rule
 DeviceEvents
 | where ActionType startswith "Asr" and ActionType endswith "Blocked"
 // Count total stats - count events and machines per rule
 | summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
-| render piechart
 
 // View ASR audit events - but remove repeating events (e.g. multiple events with same machine, rule, file and process)
 DeviceEvents
 | where ActionType startswith "ASR" and ActionType endswith "Audited"
 | summarize Timestamp =max(Timestamp) by DeviceName, ActionType,FileName, FolderPath, InitiatingProcessCommandLine, InitiatingProcessFileName, InitiatingProcessFolderPath, InitiatingProcessId, SHA1 
-| render piechart

--- a/Protection events/ExploitGuardASRStats.txt
+++ b/Protection events/ExploitGuardASRStats.txt
@@ -1,5 +1,4 @@
 // Get stats on ASR audit events - count events and machines per rule
-
 DeviceEvents
 | where ActionType startswith "Asr" and ActionType endswith "Audited"
 // Count total stats - count events and machines per rule

--- a/Protection events/ExploitGuardASRStats.txt
+++ b/Protection events/ExploitGuardASRStats.txt
@@ -1,0 +1,20 @@
+// Get stats on ASR audit events - count events and machines per rule
+
+DeviceEvents
+| where ActionType startswith "Asr" and ActionType endswith "Audited"
+// Count total stats - count events and machines per rule
+| summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
+| render piechart
+
+// Get stats on ASR blocks - count events and machines per rule
+DeviceEvents
+| where ActionType startswith "Asr" and ActionType endswith "Blocked"
+// Count total stats - count events and machines per rule
+| summarize EventCount=count(), MachinesCount=dcount(DeviceName) by ActionType
+| render piechart
+
+// View ASR audit events - but remove repeating events (e.g. multiple events with same machine, rule, file and process)
+DeviceEvents
+| where ActionType startswith "ASR" and ActionType endswith "Audited"
+| summarize Timestamp =max(Timestamp) by DeviceName, ActionType,FileName, FolderPath, InitiatingProcessCommandLine, InitiatingProcessFileName, InitiatingProcessFolderPath, InitiatingProcessId, SHA1 
+| render piechart

--- a/Protection events/ExploitGuardAsrDescriptions.txt
+++ b/Protection events/ExploitGuardAsrDescriptions.txt
@@ -25,6 +25,8 @@ let AsrDescriptionTable = datatable(RuleDescription:string, RuleGuid:string)
 "Block process creations originating from PSExec and WMI commands","d1e49aac-8f56-4280-b9ba-993a6d77406c",
 "Block untrusted and unsigned processes that run from USB","b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4",
 "Block Office communication applications from creating child processes (available for beta testing)","26190899-1602-49e8-8b27-eb1d0a1ce869",
+"Block Adobe Reader from creating child processes","7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c",
+"Block persistence through WMI event subscription","e6db77e5-3df2-4cf1-b95a-636979351e5b",
 ];
 // Now we query the DeviceEvents table for events where the ActionType field starts with "Asr" - which should cover values such as AsrExecutableEmailContentAudited, AsrExecutableEmailContentBlocked, AsrOfficeChildProcessAudited, ....
 DeviceEvents


### PR DESCRIPTION
Added the following ASR rules according https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/attack-surface-reduction#rule-block-executable-files-from-running-unless-they-meet-a-prevalence-age-or-trusted-list-criteria
- Block Adobe Reader from creating child processes
- Block persistence through WMI event subscription