### PR TITLE
Add initiated process correlation from MDATP

### DIFF
--- a/Discovery/Roasting.md
+++ b/Discovery/Roasting.md
@@ -1,6 +1,10 @@
 # Detect LDAP queries that search for accounts vulnerable for roasting attacks
 
-Detect Active Directory LDAP queries that search for Kerberoasting (SPNs) or accounts with Kerberos preauthentication not required
+Detect Active Directory LDAP queries that search for Kerberoasting (SPNs) or accounts with Kerberos preauthentication not required from Azure ATP, and try to get the process initiated the LDAP query from MDATP.
+
+Replace 389 on line 5 with LDAP port in your environment
+
+Replace true on line 6 to false if you want to include Nt Authority process
 
 This LDAP query cover Rubeus, Kerberoast, BloodHound tools
 
@@ -11,6 +15,9 @@ let ASREP_ROASTING = "userAccountControl:1.2.840.113556.1.4.803:=4194304";
 let ASREP_ROASTING1 = "userAccountControl|4194304";
 let ASREP_ROASTING2 = "userAccountControl&4194304";
 let KERBEROASTING = "serviceprincipalname=*";
+let LDAP_PORT = 389;
+let ExcludeNtAuthorityProcess = true;
+let AzureAtpLdap = (
 IdentityQueryEvents
 | where ActionType == "LDAP query"
 | parse Query with * "Search Scope: " SearchScope ", Base Object:" BaseObject ", Search Filter: " SearchFilter
@@ -18,6 +25,18 @@ IdentityQueryEvents
 SearchFilter contains ASREP_ROASTING1 or
 SearchFilter contains ASREP_ROASTING2 or
 SearchFilter contains KERBEROASTING
+| extend Time = bin(Timestamp, 1s)
+| extend DeviceNameWithoutDomain = tolower(tostring(split(DeviceName, '.')[0])));
+let MDAtpNetworkToProcess = (
+DeviceNetworkEvents
+| extend DeviceNameWithoutDomain = tolower(tostring(split(DeviceName, '.')[0]))
+| where RemotePort == LDAP_PORT
+| extend Time = bin(Timestamp, 1s)
+| extend isExclude = iff( ExcludeNtAuthorityProcess and InitiatingProcessAccountDomain == "nt authority" , true, false));
+AzureAtpLdap
+| join kind=leftouter (
+MDAtpNetworkToProcess ) on DeviceNameWithoutDomain, Time 
+| where isExclude == false or isnull(isExclude)
 
 ```
 ## Category


### PR DESCRIPTION
correlate Azure ATP relevant LDAPs with MDATP network activities to find the process initiated the request for better investigation