### PR TITLE
Update scheduled task creation.txt

### DIFF
--- a/Persistence/scheduled task creation.txt
+++ b/Persistence/scheduled task creation.txt
@@ -2,4 +2,4 @@
 //Questions via Twitter: @janvonkirchheim 
 DeviceEvents 
 | where ActionType == "ScheduledTaskCreated"
-  and InitiatingProcessAccountSid == "S-1-5-18"
+  and InitiatingProcessAccountSid != "S-1-5-18"


### PR DESCRIPTION
The original intent of the Sigma rule is to identify scheduled tasks created by user accounts, not the system account.