### PR TITLE
pages related to doublepulsar

### DIFF
--- a/Execution/detect-doublepulsar-execution.md
+++ b/Execution/detect-doublepulsar-execution.md
@@ -1,0 +1,46 @@
+# Detect DoublePulsar execution
+
+This query was originally published in the threat analytics report, *Motivated miners*.
+
+[Doublepulsar](https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Trojan:Win32/DoublePulsar&threatId=-2147239036) is a backdoor developed by the National Security Agency (NSA). First [disclosed in 2017](https://www.scmagazine.com/home/security-news/cybercrime/doublepulsar-malware-spreading-rapidly-in-the-wild-following-shadow-brokers-dump/), it is now used by many malicious actors. Software [patches](https://support.microsoft.com/en-us/help/4013389/title) are available.
+
+The following query detects possible DoublePulsar execution events.
+
+See [Detect web server exploitation by DoublePulsar](detect-web-server-exploit-double-pulsar.md) for a query that detects behaviors associated with campaigns that use DoublePulsar.
+
+## Query
+
+```Kusto
+//DoublePulsar execution
+DeviceProcessEvents
+| where Timestamp > ago(7d)
+| where SHA1 == "be855cd1bfc1e1446a3390c693f29e2a3007c04e" or
+(ProcessCommandLine contains "targetport" and ProcessCommandLine contains "targetip" and 
+(ProcessCommandLine contains "payload" or ProcessCommandLine contains "verifybackdoor"))
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|-|-|-|
+| Initial access |  |  |
+| Execution | v |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team

--- a/Execution/detect-doublepulsar-execution.md
+++ b/Execution/detect-doublepulsar-execution.md
@@ -6,7 +6,7 @@ This query was originally published in the threat analytics report, *Motivated m
 
 The following query detects possible DoublePulsar execution events.
 
-See [Detect web server exploitation by DoublePulsar](detect-web-server-exploit-double-pulsar.md) for a query that detects behaviors associated with campaigns that use DoublePulsar.
+See [Detect web server exploitation by DoublePulsar](detect-web-server-exploit-doublepulsar.md) for a query that detects behaviors associated with campaigns that use DoublePulsar.
 
 ## Query
 

--- a/Execution/detect-web-server-exploit-doublepulsar.md
+++ b/Execution/detect-web-server-exploit-doublepulsar.md
@@ -1,0 +1,94 @@
+# Detect web server exploitation by DoublePulsar
+
+This query was originally published in the threat analytics report, *Motivated miners*.
+
+[Doublepulsar](https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?Name=Trojan:Win32/DoublePulsar&threatId=-2147239036) is a backdoor developed by the National Security Agency (NSA). First [disclosed in 2017](https://www.scmagazine.com/home/security-news/cybercrime/doublepulsar-malware-spreading-rapidly-in-the-wild-following-shadow-brokers-dump/), it is now used by many malicious actors. Software [patches](https://support.microsoft.com/help/4013389/title) are available.
+
+The following query detects activity broadly associated with campaigns that use DoublePulsar to exploit web servers.
+
+See [Detect DoublePulsar execution](detect-doublepulsar-execution.md) for a query that detects possible DoublePulsar execution events.
+
+## Query
+
+```Kusto
+DeviceProcessEvents
+| where Timestamp >= ago(7d)
+| where 
+// "Grandparent" process is Oracle WebLogic or some process loading Confluence
+InitiatingProcessParentFileName == "beasvc.exe" or 
+InitiatingProcessFileName == "beasvc.exe" 
+or InitiatingProcessCommandLine contains "//confluence"
+// Calculate for Base64 in Commandline
+| extend Caps = countof(ProcessCommandLine, "[A-Z]", "regex"), 
+Total = countof(ProcessCommandLine, ".", "regex")
+| extend Ratio = todouble(Caps) / todouble(Total) 
+| where
+(
+    FileName in~ ("powershell.exe" , "powershell_ise.exe") // PowerShell is spawned
+    // Omit known clean processes
+    and ProcessCommandLine !startswith "POWERSHELL.EXE  -C \"GET-WMIOBJECT -COMPUTERNAME"
+    and ProcessCommandLine !contains "ApplicationNo"
+    and ProcessCommandLine !contains "CustomerGroup"
+    and ProcessCommandLine !contains "Cosmos"
+    and ProcessCommandLine !contains "Unrestricted"
+    and
+    (
+        ProcessCommandLine contains "$" // PowerShell variable declaration
+        or ProcessCommandLine contains "-e " // Alias for "-EncodedCommand" parameter
+        or ProcessCommandLine contains "encodedcommand"
+        or ProcessCommandLine contains "wget"
+        //or ( Ratio > 0.4 and Ratio < 1.0) // Presence of Base64 strings
+    )
+)
+or
+(
+    FileName =~ "cmd.exe" // cmd.exe is spawned
+    and ProcessCommandLine contains "@echo" and 
+    ProcessCommandLine contains ">" // Echoing commands into a file
+)
+or
+(
+    FileName =~ "certutil.exe" // CertUtil.exe abuse
+    and ProcessCommandLine contains "-split" 
+    // the "-split" parameter is required to write files to the disk
+)
+| project
+       Timestamp,
+       InitiatingProcessCreationTime ,
+       DeviceId ,
+       Grandparent_PID = InitiatingProcessParentId,
+       Grandparent = InitiatingProcessParentFileName,
+       Parent_Account = InitiatingProcessAccountName,
+       Parent_PID = InitiatingProcessId,
+       Parent = InitiatingProcessFileName ,
+       Parent_Commandline = InitiatingProcessCommandLine,
+       Child_PID = ProcessId,
+       Child = FileName ,
+       Child_Commandline = ProcessCommandLine
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|-|-|-|
+| Initial access |  |  |
+| Execution | v |  |
+| Persistence |  |  |
+| Privilege escalation |  |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+
+## Contributor info
+
+**Contributor:** Microsoft Threat Protection team


### PR DESCRIPTION
Part of a series of pull requests, placing queries from the TA reports in the repo.

Some of the column names may be outdated, as some of the reports are quite old.

Others in the series:
#145, #155, #163, #165,
#168, #169, #170, #172,
#173 , #174, #175, #177,
#178, #182, #183, #190,
#191, #192, #195, #196
#198, #202, #203, #204
#205, #206, #207, #208
#209, #214, #215

Tangentially related to https://github.com/MicrosoftDocs/security-updates/pull/637, due to a link that points to that page for more information on the CVEs and software updates.