### PR TITLE
Graph Role Management permission grant and Admin promotion via Admin Directory Role

### DIFF
--- a/Privilege escalation/AdminPromoAfterRoleMgmtAppPermissionGrant.md
+++ b/Privilege escalation/AdminPromoAfterRoleMgmtAppPermissionGrant.md
@@ -1,0 +1,74 @@
+# Admin promotion after Role Management Application Permission Grant
+
+This rule looks for a service principal being granted the Microsoft Graph RoleManagement.ReadWrite.Directory (application) permission before being used to add an Azure AD object or user account to an Admin directory role (i.e. Global Administrators). 
+* https://docs.microsoft.com/en-us/graph/permissions-reference#role-management-permissions
+* https://docs.microsoft.com/en-us/graph/api/directoryrole-post-members?view=graph-rest-1.0&tabs=http
+
+## Query
+
+```kusto
+let queryTime = 3d;
+CloudAppEvents
+| where Timestamp > ago(queryTime)
+| where Application == "Office 365"
+| where ActionType =~ "Add app role assignment to service principal."
+| extend RawEventData = parse_json(RawEventData)
+| where RawEventData.ResultStatus =~ "success"
+| extend UserAgent = parse_json(replace('-','',tostring(RawEventData.ExtendedPRoperties[0].Value))).UserAgent
+| mv-expand RawEventData.ModifiedProperties
+| extend PropertyName_ = tostring(RawEventData_ModifiedProperties.Name)
+| extend PropertyNewValue_ = tostring(RawEventData_ModifiedProperties.NewValue)
+| where PropertyName_ =~ "AppRole.Value"
+| where PropertyNewValue_ contains "RoleManagement.ReadWrite.Directory"
+| extend Initiator = AccountDisplayName, InitiatorId = AccountId,
+  Target = tostring(RawEventData.ModifiedProperties[4].NewValue),
+  TargetId = tostring(RawEventData.ModifiedProperties[3].NewValue)
+| project Timestamp, Initiator, InitiatorId, Target, TargetId
+| join (
+  CloudAppEvents
+  | where Timestamp > ago(queryTime)
+  | where Application == "Office 365"
+  | where ActionType == "Add member to role."
+  | where ObjectType == "Office 365 Admin Role"
+  | where ActivityType == "Assignprivilege"
+  | where AccountType == "Application"
+  | extend Initiator = tostring(RawEventData.Actor[0].ID), InitiatorId = tostring(RawEventData.Actor[3].ID),
+    Target = tostring(RawEventData.Target[3].ID), TargetId = tostring(RawEventData.Target[1].ID),
+    TargetType = tostring(RawEventData.Target[2].ID), RoleName = ObjectName, RoleId = ObjectId
+  | project Timestamp, Initiator, InitiatorId, Target, TargetId, TargetType, RoleName, RoleId
+) on $left.TargetId == $right.InitiatorId
+| extend TimeRoleMgGrant = Timestamp, TimeAdminPromo = Timestamp1, ServicePrincipal = Initiator1, ServicePrincipalId = InitiatorId1,
+  TargetObject = Target1, TargetObjectId = TargetId1, TargetObjectType = TargetType
+| where TimeRoleMgGrant < TimeAdminPromo
+| project TimeRoleMgGrant, TimeAdminPromo, RoleName, ServicePrincipal, ServicePrincipalId, TargetObject, TargetObjectId, TargetObjectType
+| extend timestamp = TimeRoleMgGrant, AccountCustomEntity = TargetObject
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation | V |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+
+## See also
+
+## Contributor info
+
+**Contributor:** Roberto Rodriguez
+**GitHub alias:** @Cyb3rWard0g
+**Organization:** Microsoft Threat Intelligence Center (MSTIC) R&D

--- a/Privilege escalation/AzureADRoleManagementPermissionGrant.md
+++ b/Privilege escalation/AzureADRoleManagementPermissionGrant.md
@@ -1,0 +1,58 @@
+# Azure AD Role Management Permission Grant
+
+Identifies when the Microsoft Graph RoleManagement.ReadWrite.Directory (Delegated or Application) permission is granted to a service principal. This permission allows an application to read and manage the role-based access control (RBAC) settings for your company's directory. An adversary could use this permission to add an Azure AD object to an Admin directory role.
+* https://docs.microsoft.com/en-us/graph/permissions-reference#role-management-permissions
+* https://docs.microsoft.com/en-us/graph/api/directoryrole-post-members?view=graph-rest-1.0&tabs=http'
+
+## Query
+
+```kusto
+let queryTime = 3d;
+CloudAppEvents
+| where Timestamp > ago(queryTime)
+| where Application == "Office 365"
+| where ActionType has_any ("Add delegated permission grant.","Add app role assignment to service principal.")
+| extend RawEventData = parse_json(RawEventData)
+| where RawEventData.ResultStatus =~ "success"
+| extend UserAgent = parse_json(replace('-','',tostring(RawEventData.ExtendedPRoperties[0].Value))).UserAgent
+| mv-expand RawEventData.ModifiedProperties
+| extend PropertyName_ = tostring(RawEventData_ModifiedProperties.Name)
+| extend PropertyNewValue_ = tostring(RawEventData_ModifiedProperties.NewValue)
+| where PropertyName_ has_any ("AppRole.Value","DelegatedPermissionGrant.Scope")
+| where PropertyNewValue_ contains "RoleManagement.ReadWrite.Directory"
+| extend Initiator = AccountDisplayName, InitiatorId = AccountId,
+  Target = tostring(RawEventData.ModifiedProperties[4].NewValue),
+  TargetId = iif(PropertyName_ =~ 'DelegatedPermissionGrant.Scope',
+    tostring(RawEventData.ModifiedProperties[2].NewValue),
+    tostring(RawEventData.ModifiedProperties[3].NewValue))
+| project Timestamp, Initiator, InitiatorId, Target, TargetId, ActionType
+```
+
+## Category
+
+This query can be used to detect the following attack techniques and tactics ([see MITRE ATT&CK framework](https://attack.mitre.org/)) or security configuration states.
+| Technique, tactic, or state | Covered? (v=yes) | Notes |
+|------------------------|----------|-------|
+| Initial access |  |  |
+| Execution |  |  |
+| Persistence |  |  |
+| Privilege escalation | V |  |
+| Defense evasion |  |  |
+| Credential Access |  |  |
+| Discovery |  |  |
+| Lateral movement |  |  |
+| Collection |  |  |
+| Command and control |  |  |
+| Exfiltration |  |  |
+| Impact |  |  |
+| Vulnerability |  |  |
+| Misconfiguration |  |  |
+| Malware, component |  |  |
+
+## See also
+
+## Contributor info
+
+**Contributor:** Roberto Rodriguez
+**GitHub alias:** @Cyb3rWard0g
+**Organization:** Microsoft Threat Intelligence Center (MSTIC) R&D


### PR DESCRIPTION
Detection rule for:
* RoleManagement.ReadWrite.Directory permission grants
* Service principal being granted the Microsoft Graph RoleManagement.ReadWrite.Directory (application) permission before being used to add an Azure AD object or user account to an Admin directory role (i.e. Global Administrators).

## References:
* https://docs.microsoft.com/en-us/graph/permissions-reference#role-management-permissions
* https://docs.microsoft.com/en-us/graph/api/directoryrole-post-members?view=graph-rest-1.0&tabs=http