### PR TITLE
specified Windows Powershell

### DIFF
--- a/Execution/PowerShell downloads.txt
+++ b/Execution/PowerShell downloads.txt
@@ -1,4 +1,4 @@
-// Finds PowerShell execution events that could involve a download.
+// Finds Windows PowerShell execution events that could involve a download.
 DeviceProcessEvents
 | where Timestamp > ago(7d)
 | where FileName in~ ("powershell.exe", "powershell_ise.exe")


### PR DESCRIPTION
The executables in this hunting query are for _Windows_ PowerShell specifically. PowerShell, not be confused with Windows PowerShell has a different executable name. Slightly modified comments to make this distinction. Please see Microsoft doc about executable name pwsh.exe, different from the Windows PowerShell executable name: https://docs.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.2